### PR TITLE
Allow ip overide for connection test

### DIFF
--- a/airootfs/usr/bin/cnchi-start.sh
+++ b/airootfs/usr/bin/cnchi-start.sh
@@ -10,4 +10,15 @@ sudo rm /home/rebornos/Downloads/reborn-mirrorlist
 sudo rm /home/rebornos/Downloads/mirrorlist
 sudo chmod 644 /etc/pacman.conf
 sudo chmod 0777 /usr/share/cnchi/scripts/ckbcomp
+if [ "$#" -eq 1 ]; then
+    if echo "$1" | grep -q -E '(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}'; then
+        echo "IP address received for checking the internet: $1"
+        reversed_ip=$(echo -n "$1." | tac -s'.' | sed 's/.$//')
+        sudo sed -i "s/1.1.1.1/$reversed_ip/g" /usr/share/cnchi/src/misc/extra.py
+    else
+        echo "ERROR: Invalid IP: $1..."
+        echo "Please run again with a valid IP address of the form abc.def.ghi.jkl"
+        exit 1
+    fi
+fi
 sudo -E /usr/bin/python -Wall /usr/share/cnchi/src/cnchi.py -dvz --no-check --packagelist /usr/share/cnchi/data/packages.xml


### PR DESCRIPTION
We had a user where the connection test failed with the default ip of `1.1.1.1`
This will allow them to supply their own ip for the connection test like so 
```
sudo cnchi-start.sh 8.8.8.8
```
Code credit to shivanandvp